### PR TITLE
flatten background while convert transparent image

### DIFF
--- a/src/Utility/Image.php
+++ b/src/Utility/Image.php
@@ -19,6 +19,10 @@ class Image
             Storage::disk($disk)->get($sourceFile)
         );
 
+        if ($image->hasAlpha()) {
+            $image = $image->flatten(['background' => [255, 255, 255]]);
+        }
+
         $width = min($image->width, $width);
         $height = min($image->height, $height);
         $ext = pathinfo($targetFile, PATHINFO_EXTENSION);
@@ -44,6 +48,10 @@ class Image
         $image = VipsImage::newFromBuffer(
             Storage::disk($disk)->get($sourceFile)
         );
+
+        if ($image->hasAlpha()) {
+            $image = $image->flatten(['background' => [255, 255, 255]]);
+        }
 
         $ext = pathinfo($targetFile, PATHINFO_EXTENSION);
 


### PR DESCRIPTION
## Problem
When converting PNG images with transparency to JPG, the transparent areas become black. JPG doesn’t support transparency, so it should use a solid background color instead.

## Suggested Fix
Check if the image has an alpha channel and flatten it on a white background before writing to JPG:

```php
if ($image->hasAlpha()) {
    $image = $image->flatten(['background' => [255, 255, 255]]);
}
```
This ensures transparent areas become white instead of black.